### PR TITLE
add nueral-pbir quantitative results

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
                     <td class="table_elem">IDR</td>
                     <td class="table_elem">0.35</td>
                     <td class="table_elem">0.05</td>
-                    <td class="table_elem table_emph">0.30</td>
+                    <td class="table_elem">0.30</td>
                     <td class="table_elem align-middle" colspan="4">N/A</td>
                     <td class="table_elem table_emph">30.11</td>
                     <td class="table_elem table_emph">39.66</td>
@@ -379,7 +379,7 @@
                 </tr>
                 <tr>
                     <td class="table_elem">NVDiffRec</td>
-                    <td class="table_elem table_emph">0.31</td>
+                    <td class="table_elem">0.31</td>
                     <td class="table_elem">0.06</td>
                     <td class="table_elem">0.62</td>
 
@@ -447,15 +447,31 @@
                     <td class="table_elem table_emph">0.04</td>
                     <td class="table_elem">0.51</td>
 
-                    <td class="table_elem table_emph">24.43</td>
-                    <td class="table_elem table_emph">31.60</td>
-                    <td class="table_elem table_emph">0.972</td>
-                    <td class="table_elem table_emph">0.036</td>
+                    <td class="table_elem">24.43</td>
+                    <td class="table_elem">31.60</td>
+                    <td class="table_elem">0.972</td>
+                    <td class="table_elem">0.036</td>
 
                     <td class="table_elem">28.03</td>
                     <td class="table_elem">36.40</td>
                     <td class="table_elem">0.982</td>
                     <td class="table_elem">0.028</td>
+                </tr>                 
+                <tr>
+                    <td class="table_elem">Neural-PBIR</td>
+                    <td class="table_elem table_emph">0.30</td>
+                    <td class="table_elem">0.06</td>
+                    <td class="table_elem table_emph">0.21</td>
+
+                    <td class="table_elem table_emph">26.01</td>
+                    <td class="table_elem table_emph">33.26</td>
+                    <td class="table_elem table_emph">0.979</td>
+                    <td class="table_elem table_emph">0.023</td>
+
+                    <td class="table_elem">28.83</td>
+                    <td class="table_elem">36.80</td>
+                    <td class="table_elem">0.987</td>
+                    <td class="table_elem">0.019</td>
                 </tr>                 
                 <tr>
                     <th class="table_elem align-middle" colspan="12" scope="col" style="padding: 5px">Single-View Prediction Methods</th>


### PR DESCRIPTION
Hi Stanford-ORB team,

Thanks for creating such an awesome benchmark! 

I'm the co-first author of [Neural-PBIR](https://neural-pbir.github.io/) (ICCV'23), Guangyan Cai and I have run and evaluate Nueral-PBIR on your dataset. You can access all our reconstruction results through [this link](https://drive.google.com/drive/folders/1d6HOIEgGD_dEjmipbQjdTekjobTMZMID?usp=drive_link). Here are some more details:
- We use our default hyperparameters for all `42` scenes.
- Following your repository guidelines, we use `512x512` benchmark resolution for both optimization and evaluation.
- The quantitative results are obtained by running your `scripts/test.py`, and the output json file can be found [here](https://drive.google.com/file/d/1TVmKX8TVx0rECTM51TRtBDTcbIlABk9y/view?usp=sharing).

We plan to update our results into the arxiv version of Neural-PBIR and would greatly appreciate it if you could consider merging our results also into your page.

Best regards,
Cheng Sun